### PR TITLE
🐛 Fix delete books

### DIFF
--- a/resolvers/books/mutation/delete.js
+++ b/resolvers/books/mutation/delete.js
@@ -2,7 +2,8 @@ module.exports = {
   deleteBook: async (_, { id }, { db }) => {
     const [bookDelete] = await db("books")
       .where({ id })
-      .returning("id", "title", "author_id as authorId");
+      .returning(["id", "title", "author_id as authorId", "author_id"])
+      .del();
     if (!bookDelete) {
       throw new Error("Book not found");
     }
@@ -11,5 +12,9 @@ module.exports = {
       ...bookDelete,
       authorId: bookDelete.author_id,
     };
+  },
+  catch(err) {
+    console.error("Error deleting book", err);
+    throw new Error("Erro ao deletar livro:");
   },
 };


### PR DESCRIPTION
A Mutation de delete books estava retornando somente o id title e authorId e não estava deletando, foi atualizado incluindo o campo  author_id no returning para obter todas as informações necessarias de uma vez só e tambem incluido a propria função delete.